### PR TITLE
Fix comment wording in vocabulary.yml

### DIFF
--- a/vocab/src/vocabulary.yml
+++ b/vocab/src/vocabulary.yml
@@ -414,7 +414,7 @@ property:
       - EuccLimitLiabilityCompany
       - EuccPartnership
     range: xsd:string
-    comment: a name under which the legal entity is registered
+    comment: the name under which the legal entity is registered
     defined_by: https://sanastot.suomi.fi/en/terminology/webuild/concept/legalname
 
   - id: legalIdentifier


### PR DESCRIPTION
"a name" is ambiqu
normally we have the statutory name
and trade name(s)

"the name" is used in the terminology